### PR TITLE
Add miner block with block entity and GUI

### DIFF
--- a/src/generated/resources/assets/cryptoworld/blockstates/miner_block.json
+++ b/src/generated/resources/assets/cryptoworld/blockstates/miner_block.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "cryptoworld:block/miner_block"
+    }
+  }
+}

--- a/src/generated/resources/assets/cryptoworld/models/block/miner_block.json
+++ b/src/generated/resources/assets/cryptoworld/models/block/miner_block.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "cryptoworld:block/miner_block"
+  }
+}

--- a/src/generated/resources/assets/cryptoworld/models/item/miner_block.json
+++ b/src/generated/resources/assets/cryptoworld/models/item/miner_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "cryptoworld:block/miner_block"
+}

--- a/src/generated/resources/data/cryptoworld/loot_tables/blocks/miner_block.json
+++ b/src/generated/resources/data/cryptoworld/loot_tables/blocks/miner_block.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "cryptoworld:miner_block"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "cryptoworld:blocks/miner_block"
+}

--- a/src/generated/resources/data/cryptoworld/recipes/miner_block.json
+++ b/src/generated/resources/data/cryptoworld/recipes/miner_block.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "IGI",
+    "RFR",
+    "III"
+  ],
+  "key": {
+    "I": { "item": "minecraft:iron_ingot" },
+    "G": { "item": "cryptoworld:gtx_1080" },
+    "R": { "item": "cryptoworld:ram" },
+    "F": { "item": "cryptoworld:silicium_hypercharged" }
+  },
+  "result": { "item": "cryptoworld:miner_block" }
+}

--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -5,6 +5,7 @@
     "cryptoworld:cryptonium_block",
     "cryptoworld:server_block",
     "cryptoworld:silicium_ore",
-    "cryptoworld:silicium_block"
+    "cryptoworld:silicium_block",
+    "cryptoworld:miner_block"
   ]
 }

--- a/src/generated/resources/data/minecraft/tags/blocks/needs_iron_tool.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/needs_iron_tool.json
@@ -1,6 +1,7 @@
 {
   "values": [
     "cryptoworld:silicium_ore",
-    "cryptoworld:server_block"
+    "cryptoworld:server_block",
+    "cryptoworld:miner_block"
   ]
 }

--- a/src/main/java/fr/jachou/cryptoworld/CryptoWorld.java
+++ b/src/main/java/fr/jachou/cryptoworld/CryptoWorld.java
@@ -1,6 +1,10 @@
 package fr.jachou.cryptoworld;
 
 import fr.jachou.cryptoworld.block.ModBlocks;
+import fr.jachou.cryptoworld.blockentity.ModBlockEntities;
+import fr.jachou.cryptoworld.menu.ModMenuTypes;
+import fr.jachou.cryptoworld.screen.MinerScreen;
+import net.minecraft.client.gui.screens.MenuScreens;
 import fr.jachou.cryptoworld.datagen.DataGenerators;
 import fr.jachou.cryptoworld.item.ModCreativeModTabs;
 import fr.jachou.cryptoworld.item.ModItems;
@@ -24,6 +28,8 @@ public class CryptoWorld {
         ModCreativeModTabs.register(bus);
         ModItems.register(bus);
         ModBlocks.register(bus);
+        ModBlockEntities.register(bus);
+        ModMenuTypes.register(bus);
 
         bus.addListener(this::setup);
         MinecraftForge.EVENT_BUS.register(this);
@@ -43,5 +49,6 @@ public class CryptoWorld {
     }
 
     private void doClientStuff(final FMLClientSetupEvent event) {
+        MenuScreens.register(ModMenuTypes.MINER_MENU.get(), MinerScreen::new);
     }
 }

--- a/src/main/java/fr/jachou/cryptoworld/block/MinerBlock.java
+++ b/src/main/java/fr/jachou/cryptoworld/block/MinerBlock.java
@@ -1,0 +1,51 @@
+package fr.jachou.cryptoworld.block;
+
+import fr.jachou.cryptoworld.blockentity.MinerBlockEntity;
+import fr.jachou.cryptoworld.blockentity.ModBlockEntities;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.network.NetworkHooks;
+import org.jetbrains.annotations.Nullable;
+
+public class MinerBlock extends Block implements EntityBlock {
+    public MinerBlock(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player,
+                                 InteractionHand hand, BlockHitResult hit) {
+        if (!level.isClientSide) {
+            BlockEntity blockEntity = level.getBlockEntity(pos);
+            if (blockEntity instanceof MinerBlockEntity) {
+                NetworkHooks.openScreen((ServerPlayer) player, (MinerBlockEntity) blockEntity, pos);
+            } else {
+                throw new IllegalStateException("Missing miner block entity!");
+            }
+        }
+        return InteractionResult.sidedSuccess(level.isClientSide);
+    }
+
+    @Nullable
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new MinerBlockEntity(pos, state);
+    }
+
+    @Nullable
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> type) {
+        return level.isClientSide ? null : createTickerHelper(type, ModBlockEntities.MINER_BLOCK_ENTITY.get(), MinerBlockEntity::tick);
+    }
+}

--- a/src/main/java/fr/jachou/cryptoworld/block/ModBlocks.java
+++ b/src/main/java/fr/jachou/cryptoworld/block/ModBlocks.java
@@ -1,6 +1,7 @@
 package fr.jachou.cryptoworld.block;
 
 import fr.jachou.cryptoworld.CryptoWorld;
+import fr.jachou.cryptoworld.block.MinerBlock;
 import fr.jachou.cryptoworld.item.ModItems;
 import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.item.BlockItem;
@@ -20,6 +21,9 @@ import java.util.function.Supplier;
 public class ModBlocks {
     public static final DeferredRegister<Block> BLOCKS =
             DeferredRegister.create(ForgeRegistries.BLOCKS, CryptoWorld.MODID);
+
+    public static final RegistryObject<Block> MINER_BLOCK = registerBlock("miner_block",
+            () -> new MinerBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.IRON_BLOCK)));
 
     public static final RegistryObject<Block> SERVER_BLOCK = registerBlock("server_block",
             () -> new Block(BlockBehaviour.Properties.ofFullCopy(Blocks.IRON_BLOCK)));

--- a/src/main/java/fr/jachou/cryptoworld/blockentity/MinerBlockEntity.java
+++ b/src/main/java/fr/jachou/cryptoworld/blockentity/MinerBlockEntity.java
@@ -1,0 +1,119 @@
+package fr.jachou.cryptoworld.blockentity;
+
+import fr.jachou.cryptoworld.item.ModItems;
+import fr.jachou.cryptoworld.menu.MinerMenu;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemStackHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MinerBlockEntity extends BlockEntity implements net.minecraft.world.MenuProvider {
+    private final ItemStackHandler itemHandler = new ItemStackHandler(4) {
+        @Override
+        protected void onContentsChanged(int slot) {
+            setChanged();
+        }
+
+        @Override
+        public boolean isItemValid(int slot, @NotNull ItemStack stack) {
+            return switch (slot) {
+                case 0 -> stack.is(ModItems.GTX_1080.get()) || stack.is(ModItems.RTX_2080.get());
+                case 1 -> stack.is(ModItems.RAM.get());
+                case 2 -> stack.is(ModItems.SILICIUM_HYPERCHARGED.get());
+                case 3 -> stack.is(ModItems.BITCOIN.get()) || stack.is(ModItems.ETHEREUM.get());
+                default -> super.isItemValid(slot, stack);
+            };
+        }
+    };
+
+    private LazyOptional<IItemHandler> lazyItemHandler = LazyOptional.empty();
+
+    public MinerBlockEntity(BlockPos pos, BlockState state) {
+        super(ModBlockEntities.MINER_BLOCK_ENTITY.get(), pos, state);
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        lazyItemHandler = LazyOptional.of(() -> itemHandler);
+    }
+
+    @Override
+    public void invalidateCaps() {
+        super.invalidateCaps();
+        lazyItemHandler.invalidate();
+    }
+
+    @NotNull
+    @Override
+    public <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable net.minecraft.core.Direction side) {
+        if (cap == ForgeCapabilities.ITEM_HANDLER) {
+            return lazyItemHandler.cast();
+        }
+        return super.getCapability(cap, side);
+    }
+
+    @Override
+    protected void saveAdditional(CompoundTag tag) {
+        tag.put("inventory", itemHandler.serializeNBT());
+        super.saveAdditional(tag);
+    }
+
+    @Override
+    public void load(CompoundTag tag) {
+        super.load(tag);
+        itemHandler.deserializeNBT(tag.getCompound("inventory"));
+    }
+
+    @Override
+    public Component getDisplayName() {
+        return Component.translatable("block.cryptoworld.miner_block");
+    }
+
+    @Nullable
+    @Override
+    public AbstractContainerMenu createMenu(int id, net.minecraft.world.entity.player.Inventory inventory, Player player) {
+        return new MinerMenu(id, inventory, this);
+    }
+
+    public ItemStackHandler getItemHandler() {
+        return itemHandler;
+    }
+
+    public static void tick(Level level, BlockPos pos, BlockState state, MinerBlockEntity entity) {
+        if (level.isClientSide) {
+            return;
+        }
+
+        ItemStack gpu = entity.itemHandler.getStackInSlot(0);
+        ItemStack ram = entity.itemHandler.getStackInSlot(1);
+        ItemStack fuel = entity.itemHandler.getStackInSlot(2);
+        ItemStack output = entity.itemHandler.getStackInSlot(3);
+
+        if (!gpu.isEmpty() && !ram.isEmpty() && fuel.is(ModItems.SILICIUM_HYPERCHARGED.get())) {
+            Item coinItem = level.random.nextBoolean() ? ModItems.BITCOIN.get() : ModItems.ETHEREUM.get();
+            if (output.isEmpty()) {
+                entity.itemHandler.setStackInSlot(3, new ItemStack(coinItem));
+                fuel.shrink(1);
+                setChanged(level, pos, state);
+            } else if (output.is(coinItem) && output.getCount() < output.getMaxStackSize()) {
+                output.grow(1);
+                fuel.shrink(1);
+                setChanged(level, pos, state);
+            }
+        }
+    }
+}

--- a/src/main/java/fr/jachou/cryptoworld/blockentity/ModBlockEntities.java
+++ b/src/main/java/fr/jachou/cryptoworld/blockentity/ModBlockEntities.java
@@ -1,0 +1,21 @@
+package fr.jachou.cryptoworld.blockentity;
+
+import fr.jachou.cryptoworld.CryptoWorld;
+import fr.jachou.cryptoworld.block.ModBlocks;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+public class ModBlockEntities {
+    public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES =
+            DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, CryptoWorld.MODID);
+
+    public static final RegistryObject<BlockEntityType<MinerBlockEntity>> MINER_BLOCK_ENTITY = BLOCK_ENTITIES.register("miner_block_entity",
+            () -> BlockEntityType.Builder.of(MinerBlockEntity::new, ModBlocks.MINER_BLOCK.get()).build(null));
+
+    public static void register(IEventBus eventBus) {
+        BLOCK_ENTITIES.register(eventBus);
+    }
+}

--- a/src/main/java/fr/jachou/cryptoworld/datagen/ModBlockStateProvider.java
+++ b/src/main/java/fr/jachou/cryptoworld/datagen/ModBlockStateProvider.java
@@ -24,6 +24,7 @@ public class ModBlockStateProvider extends BlockStateProvider {
         blockWithItem(ModBlocks.SILICIUM_ORE);
         blockWithItem(ModBlocks.SILICIUM_BLOCK);
         blockWithItem(ModBlocks.SERVER_BLOCK);
+        blockWithItem(ModBlocks.MINER_BLOCK);
     }
 
     private void blockWithItem(RegistryObject<Block> blockRegistryObject) {

--- a/src/main/java/fr/jachou/cryptoworld/datagen/ModBlockTagGenerator.java
+++ b/src/main/java/fr/jachou/cryptoworld/datagen/ModBlockTagGenerator.java
@@ -29,12 +29,15 @@ public class ModBlockTagGenerator extends BlockTagsProvider {
                         ModBlocks.CRYPTONIUM_BLOCK.get(),
                         ModBlocks.SERVER_BLOCK.get(),
                         ModBlocks.SILICIUM_ORE.get(),
-                        ModBlocks.SILICIUM_BLOCK.get());
+                        ModBlocks.SILICIUM_BLOCK.get(),
+                        ModBlocks.MINER_BLOCK.get());
 
         this.tag(BlockTags.NEEDS_DIAMOND_TOOL)
                 .add(ModBlocks.CRYPTONIUM_ORE.get()).add(ModBlocks.CRYPTONIUM_BLOCK.get());
 
         this.tag(BlockTags.NEEDS_IRON_TOOL)
-                .add(ModBlocks.SILICIUM_ORE.get()).add(ModBlocks.SERVER_BLOCK.get());
+                .add(ModBlocks.SILICIUM_ORE.get())
+                .add(ModBlocks.SERVER_BLOCK.get())
+                .add(ModBlocks.MINER_BLOCK.get());
     }
 }

--- a/src/main/java/fr/jachou/cryptoworld/datagen/ModRecipeProvider.java
+++ b/src/main/java/fr/jachou/cryptoworld/datagen/ModRecipeProvider.java
@@ -64,6 +64,17 @@ public class ModRecipeProvider extends RecipeProvider implements IConditionBuild
                 .save(recipeOutput);
 
 
+        ShapedRecipeBuilder.shaped(RecipeCategory.MISC, ModBlocks.MINER_BLOCK.get())
+                .pattern("IGI")
+                .pattern("RFR")
+                .pattern("III")
+                .define('I', Items.IRON_INGOT)
+                .define('G', ModItems.GTX_1080.get())
+                .define('R', ModItems.RAM.get())
+                .define('F', ModItems.SILICIUM_HYPERCHARGED.get())
+                .unlockedBy(getHasName(ModItems.GTX_1080.get()), has(ModItems.GTX_1080.get()))
+                .save(recipeOutput);
+
     }
 
     protected static <T extends AbstractCookingRecipe> void oreCooking(RecipeOutput pRecipeOutput, RecipeSerializer<T> pCookingSerializer,

--- a/src/main/java/fr/jachou/cryptoworld/datagen/loot/ModBlockLootTables.java
+++ b/src/main/java/fr/jachou/cryptoworld/datagen/loot/ModBlockLootTables.java
@@ -23,6 +23,7 @@ public class ModBlockLootTables extends BlockLootSubProvider {
         this.dropSelf(ModBlocks.CRYPTONIUM_ORE.get());
         this.dropSelf(ModBlocks.SERVER_BLOCK.get());
         this.dropSelf(ModBlocks.SILICIUM_ORE.get());
+        this.dropSelf(ModBlocks.MINER_BLOCK.get());
     }
 
     @Override

--- a/src/main/java/fr/jachou/cryptoworld/item/ModCreativeModTabs.java
+++ b/src/main/java/fr/jachou/cryptoworld/item/ModCreativeModTabs.java
@@ -36,6 +36,7 @@ public class ModCreativeModTabs {
                         pOutput.accept(ModBlocks.SILICIUM_ORE.get());
                         pOutput.accept(ModBlocks.CRYPTONIUM_BLOCK.get());
                         pOutput.accept(ModBlocks.SILICIUM_BLOCK.get());
+                        pOutput.accept(ModBlocks.MINER_BLOCK.get());
                     })
                     .build());
 

--- a/src/main/java/fr/jachou/cryptoworld/menu/MinerMenu.java
+++ b/src/main/java/fr/jachou/cryptoworld/menu/MinerMenu.java
@@ -1,0 +1,79 @@
+package fr.jachou.cryptoworld.menu;
+
+import fr.jachou.cryptoworld.block.ModBlocks;
+import fr.jachou.cryptoworld.blockentity.MinerBlockEntity;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.SlotItemHandler;
+
+public class MinerMenu extends AbstractContainerMenu {
+    private final MinerBlockEntity blockEntity;
+    private final ContainerLevelAccess access;
+
+    public MinerMenu(int id, Inventory inv, FriendlyByteBuf extraData) {
+        this(id, inv, (MinerBlockEntity) inv.player.level().getBlockEntity(extraData.readBlockPos()));
+    }
+
+    public MinerMenu(int id, Inventory inv, MinerBlockEntity entity) {
+        super(ModMenuTypes.MINER_MENU.get(), id);
+        this.blockEntity = entity;
+        this.access = ContainerLevelAccess.create(entity.getLevel(), entity.getBlockPos());
+
+        this.addSlot(new SlotItemHandler(entity.getItemHandler(), 0, 26, 17)); // GPU
+        this.addSlot(new SlotItemHandler(entity.getItemHandler(), 1, 26, 53)); // RAM
+        this.addSlot(new SlotItemHandler(entity.getItemHandler(), 2, 56, 53)); // Fuel
+        this.addSlot(new SlotItemHandler(entity.getItemHandler(), 3, 116, 35)); // Output
+
+        addPlayerInventory(inv);
+        addPlayerHotbar(inv);
+    }
+
+    private void addPlayerInventory(Inventory inv) {
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 9; ++j) {
+                this.addSlot(new Slot(inv, j + i * 9 + 9, 8 + j * 18, 84 + i * 18));
+            }
+        }
+    }
+
+    private void addPlayerHotbar(Inventory inv) {
+        for (int i = 0; i < 9; ++i) {
+            this.addSlot(new Slot(inv, i, 8 + i * 18, 142));
+        }
+    }
+
+    @Override
+    public ItemStack quickMoveStack(Player player, int index) {
+        ItemStack stack = ItemStack.EMPTY;
+        Slot slot = this.slots.get(index);
+        int size = blockEntity.getItemHandler().getSlots();
+        if (slot != null && slot.hasItem()) {
+            ItemStack stackInSlot = slot.getItem();
+            stack = stackInSlot.copy();
+            if (index < size) {
+                if (!this.moveItemStackTo(stackInSlot, size, this.slots.size(), true)) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (!this.moveItemStackTo(stackInSlot, 0, size, false)) {
+                return ItemStack.EMPTY;
+            }
+
+            if (stackInSlot.isEmpty()) {
+                slot.set(ItemStack.EMPTY);
+            } else {
+                slot.setChanged();
+            }
+        }
+        return stack;
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        return stillValid(this.access, player, ModBlocks.MINER_BLOCK.get());
+    }
+}

--- a/src/main/java/fr/jachou/cryptoworld/menu/ModMenuTypes.java
+++ b/src/main/java/fr/jachou/cryptoworld/menu/ModMenuTypes.java
@@ -1,0 +1,21 @@
+package fr.jachou.cryptoworld.menu;
+
+import fr.jachou.cryptoworld.CryptoWorld;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.network.IContainerFactory;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+public class ModMenuTypes {
+    public static final DeferredRegister<MenuType<?>> MENUS =
+            DeferredRegister.create(ForgeRegistries.MENU_TYPES, CryptoWorld.MODID);
+
+    public static final RegistryObject<MenuType<MinerMenu>> MINER_MENU =
+            MENUS.register("miner_menu", () -> new MenuType<>((IContainerFactory<MinerMenu>) MinerMenu::new));
+
+    public static void register(IEventBus eventBus) {
+        MENUS.register(eventBus);
+    }
+}

--- a/src/main/java/fr/jachou/cryptoworld/screen/MinerScreen.java
+++ b/src/main/java/fr/jachou/cryptoworld/screen/MinerScreen.java
@@ -1,0 +1,34 @@
+package fr.jachou.cryptoworld.screen;
+
+import fr.jachou.cryptoworld.menu.MinerMenu;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Inventory;
+
+public class MinerScreen extends AbstractContainerScreen<MinerMenu> {
+    private static final ResourceLocation TEXTURE = new ResourceLocation("minecraft", "textures/gui/container/furnace.png");
+
+    public MinerScreen(MinerMenu menu, Inventory inventory, Component component) {
+        super(menu, inventory, component);
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        this.inventoryLabelY = this.imageHeight - 94;
+    }
+
+    @Override
+    protected void renderBg(GuiGraphics guiGraphics, float partialTicks, int mouseX, int mouseY) {
+        guiGraphics.blit(TEXTURE, this.leftPos, this.topPos, 0, 0, this.imageWidth, this.imageHeight);
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float delta) {
+        this.renderBackground(guiGraphics);
+        super.render(guiGraphics, mouseX, mouseY, delta);
+        this.renderTooltip(guiGraphics, mouseX, mouseY);
+    }
+}

--- a/src/main/resources/assets/cryptoworld/lang/en_us.json
+++ b/src/main/resources/assets/cryptoworld/lang/en_us.json
@@ -14,6 +14,7 @@
   "block.cryptoworld.silicium_ore": "Silicium Ore",
   "block.cryptoworld.cryptonium_block": "Cryptonium Block",
   "block.cryptoworld.silicium_block": "Silicium Block",
+  "block.cryptoworld.miner_block": "Miner",
 
   "creativetab.crypto_tab": "Crypto World",
 

--- a/src/main/resources/assets/cryptoworld/lang/fr_fr.json
+++ b/src/main/resources/assets/cryptoworld/lang/fr_fr.json
@@ -14,6 +14,7 @@
   "block.cryptoworld.silicium_ore": "Minerai de Silicium",
   "block.cryptoworld.cryptonium_block": "Bloc de Cryptonium",
   "block.cryptoworld.silicium_block": "Bloc de Silicium",
+  "block.cryptoworld.miner_block": "Mineur",
 
   "creativetab.crypto_tab": "CryptoWorld",
   "tooltip.cryptoworld.cryptoworld_detector": "Le détecteur cryptoworld permet de détcter les minerais du monde cryptoworld"


### PR DESCRIPTION
## Summary
- Add Miner Block and block entity with GPU, RAM and fuel slots to mint Bitcoin or Ethereum
- Include Miner menu and screen plus registration for block entity and menu
- Generate data assets, recipes, loot tables and tags for the Miner

## Testing
- `./gradlew runData` *(fails: Plugin [id: 'net.minecraftforge.gradle', version: '[6.0.16,6.2)'] was not found)*
- `./gradlew build` *(fails: Plugin [id: 'net.minecraftforge.gradle', version: '[6.0.16,6.2)'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc2ff0740832eac6a20af8418773f